### PR TITLE
Skip Cd output during warmup to fix startup oscillation

### DIFF
--- a/simulation/modal_worker.py
+++ b/simulation/modal_worker.py
@@ -204,7 +204,9 @@ def render_simulation(
         if result.stderr:
             print(f"stderr: {result.stderr[-500:]}")
         
-        # Extract Cd values from stdout
+        # Extract Cd values from stdout.
+        # The simulation skips the first ~3s of Cd output (warmup), so all
+        # values we see here should already be past the startup transient.
         cd_values = []
         for line in result.stdout.split('\n'):
             if 'Cd=' in line:

--- a/simulation/src/main.c
+++ b/simulation/src/main.c
@@ -928,8 +928,9 @@ int main(int argc, char* argv[]) {
             checkGLError("After rendering model");
         }
         
-        // Compute and display drag coefficient every 60 frames
-        if (frameCount % 60 == 0 && lbmGrid && useLBM) {
+        // Compute and display drag coefficient every 60 frames.
+        // Skip the first 180 frames (~3s at 60fps) to avoid startup oscillation.
+        if (frameCount > 180 && frameCount % 60 == 0 && lbmGrid && useLBM) {
             float fx, fy, fz;
             LBM_ComputeDragForce(lbmGrid, &fx, &fy, &fz);
             


### PR DESCRIPTION
## Summary
- Skip the first 180 frames (~3 seconds) of Cd output so we don't report values while the LBM solver is still settling
- Updated the comment in modal_worker.py to note that early Cd values are no longer emitted

Fixes #2