### PR TITLE
Add lift coefficient (Cl) display

### DIFF
--- a/simulation/lib/lbm.h
+++ b/simulation/lib/lbm.h
@@ -54,6 +54,9 @@ void LBM_ComputeDragForce(LBMGrid* grid, float* forceX, float* forceY, float* fo
 // Compute drag coefficient
 float LBM_ComputeDragCoefficient(LBMGrid* grid, float inletVelocity, float refArea);
 
+// Compute lift coefficient
+float LBM_ComputeLiftCoefficient(LBMGrid* grid, float inletVelocity, float refArea);
+
 // Set solid mesh
 void LBM_SetSolidMesh(LBMGrid* grid, float* triangles, int numTriangles,
                       float minX, float minY, float minZ,

--- a/simulation/modal_worker.py
+++ b/simulation/modal_worker.py
@@ -204,10 +204,11 @@ def render_simulation(
         if result.stderr:
             print(f"stderr: {result.stderr[-500:]}")
         
-        # Extract Cd values from stdout.
-        # The simulation skips the first ~3s of Cd output (warmup), so all
-        # values we see here should already be past the startup transient.
+        # Extract Cd and Cl values from stdout.
+        # The simulation skips the first ~3s of output (warmup), so all
+        # values here should already be past the startup transient.
         cd_values = []
+        cl_values = []
         for line in result.stdout.split('\n'):
             if 'Cd=' in line:
                 try:
@@ -215,11 +216,21 @@ def render_simulation(
                     cd_values.append(float(cd_str))
                 except:
                     pass
-        
-        # Get the last stable Cd value (average of last few)
+            if 'Cl=' in line:
+                try:
+                    cl_str = line.split('Cl=')[1].split()[0]
+                    cl_values.append(float(cl_str))
+                except:
+                    pass
+
+        # Get the last stable Cd/Cl values (average of last few)
         cd_value = None
         if cd_values:
             cd_value = sum(cd_values[-5:]) / len(cd_values[-5:])
+
+        cl_value = None
+        if cl_values:
+            cl_value = sum(cl_values[-5:]) / len(cl_values[-5:])
             
         if result.returncode != 0:
             return {"status": "error", "error": f"Crashed: {result.stderr[-300:]}"}
@@ -260,6 +271,7 @@ def render_simulation(
             "model": model,
             "wind_speed": wind_speed,
             "cd_value": cd_value,
+            "cl_value": cl_value,
         }
         
     except subprocess.TimeoutExpired:
@@ -405,5 +417,7 @@ def main(
             print(f"URL: {url}")
     if result.get("cd_value"):
         print(f"Drag Coefficient (Cd): {result['cd_value']:.4f}")
+    if result.get("cl_value"):
+        print(f"Lift Coefficient (Cl): {result['cl_value']:.4f}")
     if result.get("error"):
         print(f"Error: {result['error']}")

--- a/simulation/src/lbm.c
+++ b/simulation/src/lbm.c
@@ -273,6 +273,25 @@ float LBM_ComputeDragCoefficient(LBMGrid* grid, float inletVelocity, float refAr
     return Cd;
 }
 
+float LBM_ComputeLiftCoefficient(LBMGrid* grid, float inletVelocity, float refArea) {
+    float fx, fy, fz;
+    LBM_ComputeDragForce(grid, &fx, &fy, &fz);
+
+    // Lift force is in y direction (vertical)
+    float liftForce = fabsf(fy);
+
+    // Cl = F / (0.5 * rho * U^2 * A)
+    // In lattice units, rho = 1
+    float rho = 1.0f;
+    float dynamicPressure = 0.5f * rho * inletVelocity * inletVelocity;
+
+    if (dynamicPressure * refArea < 1e-10f) return 0.0f;
+
+    float Cl = liftForce / (dynamicPressure * refArea);
+
+    return Cl;
+}
+
 void LBM_SetSolidMesh(LBMGrid* grid, float* triangles, int numTriangles,
                       float minX, float minY, float minZ,
                       float maxX, float maxY, float maxZ) {

--- a/simulation/src/main.c
+++ b/simulation/src/main.c
@@ -940,8 +940,9 @@ int main(int argc, char* argv[]) {
             float refArea = (carBounds.maxY - carBounds.minY) * scaleY
                           * (carBounds.maxZ - carBounds.minZ) * scaleZ;
             float Cd = LBM_ComputeDragCoefficient(lbmGrid, windSpeed * 0.05f, refArea);
-            
-            printf("  Drag Force: (%.4f, %.4f, %.4f), Cd=%.3f\n", fx, fy, fz, Cd);
+            float Cl = LBM_ComputeLiftCoefficient(lbmGrid, windSpeed * 0.05f, refArea);
+
+            printf("  Drag Force: (%.4f, %.4f, %.4f), Cd=%.3f Cl=%.3f\n", fx, fy, fz, Cd, Cl);
         }
         
         if (maxFrames > 0 && frameCount >= maxFrames) {

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -116,6 +116,7 @@ export default function Home() {
         const result: SimulationResult = {
           videoUrl: data.video_url,
           cdValue: data.cd_value ?? null,
+          clValue: data.cl_value ?? null,
           model: params.model,
           windSpeed: params.windSpeed,
           timestamp: Date.now(),

--- a/website/src/components/ResultsPanel.tsx
+++ b/website/src/components/ResultsPanel.tsx
@@ -3,6 +3,7 @@
 export interface SimulationResult {
   videoUrl: string;
   cdValue: number | null;
+  clValue: number | null;
   model: string;
   windSpeed: number;
   timestamp: number;
@@ -32,7 +33,7 @@ export default function ResultsPanel({ current, history, onSelect }: ResultsPane
 
       {/* Current result summary */}
       {current && (
-        <div className="grid grid-cols-2 gap-2 text-xs mb-3">
+        <div className="grid grid-cols-3 gap-2 text-xs mb-3">
           <div className="border border-ctp-surface1 rounded p-3">
             <div className="text-ctp-overlay1 mb-1">Drag Coefficient</div>
             <div className="text-2xl font-mono text-ctp-text">
@@ -40,6 +41,15 @@ export default function ResultsPanel({ current, history, onSelect }: ResultsPane
             </div>
             <div className="text-ctp-overlay0 mt-0.5">
               C<sub>d</sub>
+            </div>
+          </div>
+          <div className="border border-ctp-surface1 rounded p-3">
+            <div className="text-ctp-overlay1 mb-1">Lift Coefficient</div>
+            <div className="text-2xl font-mono text-ctp-text">
+              {current.clValue !== null ? current.clValue.toFixed(4) : '--'}
+            </div>
+            <div className="text-ctp-overlay0 mt-0.5">
+              C<sub>l</sub>
             </div>
           </div>
           <div className="border border-ctp-surface1 rounded p-3">
@@ -68,6 +78,7 @@ export default function ResultsPanel({ current, history, onSelect }: ResultsPane
                   <th className="py-1.5 pr-2 text-ctp-subtext0 font-medium">Model</th>
                   <th className="py-1.5 pr-2 text-ctp-subtext0 font-medium">Wind</th>
                   <th className="py-1.5 pr-2 text-ctp-subtext0 font-medium">C<sub>d</sub></th>
+                  <th className="py-1.5 pr-2 text-ctp-subtext0 font-medium">C<sub>l</sub></th>
                   <th className="py-1.5 text-ctp-subtext0 font-medium"></th>
                 </tr>
               </thead>
@@ -87,6 +98,9 @@ export default function ResultsPanel({ current, history, onSelect }: ResultsPane
                       </td>
                       <td className="py-1.5 pr-2 font-mono text-ctp-text">
                         {result.cdValue !== null ? result.cdValue.toFixed(4) : '--'}
+                      </td>
+                      <td className="py-1.5 pr-2 font-mono text-ctp-text">
+                        {result.clValue !== null ? result.clValue.toFixed(4) : '--'}
                       </td>
                       <td className="py-1.5">
                         {!isCurrent && (


### PR DESCRIPTION
## Summary
- Add `LBM_ComputeLiftCoefficient` using the Y (vertical) force component
- Print Cl alongside Cd in the simulation stdout
- Parse and return `cl_value` from the Modal worker
- Display Cl in the results panel and comparison table on the website

Closes #4