### PR TITLE
Fix memory leaks in shader loading

### DIFF
--- a/simulation/src/opengl_utils.c
+++ b/simulation/src/opengl_utils.c
@@ -33,13 +33,20 @@ GLuint loadShader(const char* path, GLenum type) {
     glDeleteShader(shader); // Delete the shader object
     return 0;
   }
+  free(source);
   return shader;
 }
 
 // Create a shader program for vertex and fragment shaders
 GLuint createShaderProgram(const char* vertexPath, const char* fragmentPath) {
   GLuint vertexShader = loadShader(vertexPath, GL_VERTEX_SHADER);
+  if (!vertexShader) return 0;
+
   GLuint fragmentShader = loadShader(fragmentPath, GL_FRAGMENT_SHADER);
+  if (!fragmentShader) {
+    glDeleteShader(vertexShader);
+    return 0;
+  }
 
   GLuint program = glCreateProgram();
   glAttachShader(program, vertexShader);
@@ -52,6 +59,8 @@ GLuint createShaderProgram(const char* vertexPath, const char* fragmentPath) {
     char log[1024];
     glGetProgramInfoLog(program, sizeof(log), NULL, log);
     printf("Shader linking error: %s\n", log);
+    glDeleteShader(vertexShader);
+    glDeleteShader(fragmentShader);
     glDeleteProgram(program);
     return 0;
   }
@@ -64,6 +73,7 @@ GLuint createShaderProgram(const char* vertexPath, const char* fragmentPath) {
 // Create a compute shader program
 GLuint createComputeShader(const char* computePath) {
   GLuint computeShader = loadShader(computePath, GL_COMPUTE_SHADER);
+  if (!computeShader) return 0;
 
   GLuint program = glCreateProgram();
   glAttachShader(program, computeShader);
@@ -75,6 +85,7 @@ GLuint createComputeShader(const char* computePath) {
     char log[1024];
     glGetProgramInfoLog(program, sizeof(log), NULL, log);
     printf("Shader linking error: %s\n", log);
+    glDeleteShader(computeShader);
     glDeleteProgram(program);
     return 0;
   }


### PR DESCRIPTION
Closes #3

## Summary
- `loadShader()` was leaking the malloc'd source buffer on every successful shader load -- it only freed on the error path, never on success.
- `createShaderProgram()` and `createComputeShader()` had no early-out when `loadShader` returned 0, so they'd proceed with invalid handles and skip cleanup. Also, on link failure the intermediate shader objects were never deleted.

The rest of the codebase (LBM buffers, particle system, main loop cleanup) checked out fine -- all `glGenBuffers` have matching `glDeleteBuffers`, and `LBM_Free` covers everything `LBM_Create` allocates. No per-frame allocations in the render loop either.

## Test plan
- [ ] Build and run a long simulation session, confirm GPU memory stays flat
- [ ] Deliberately break a shader file path to exercise the new error paths