### PR TITLE
Add smoke test to CI simulation build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build
         run: cmake --build build -j$(nproc)
 
+      - name: Smoke test
+        run: ./build/3d_fluid_simulation_car --help
+
   build-website:
     name: Build website (Next.js)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `--help` smoke test step after the simulation build in CI
- Verifies the binary starts up and prints usage, catching runtime issues beyond compilation errors

## Test plan
- [ ] CI passes with the new smoke test step

Closes #41