### PR TITLE
Add regularized collision for high Re stability

### DIFF
--- a/simulation/lib/lbm.h
+++ b/simulation/lib/lbm.h
@@ -25,8 +25,11 @@ typedef struct {
     GLint collide_gridSizeLoc;
     GLint collide_tauLoc;
     GLint collide_inletVelLoc;
+    GLint collide_useRegularizedLoc;
     GLint stream_gridSizeLoc;
     GLint force_gridSizeLoc;
+
+    int useRegularized;  // 0 = BGK, 1 = regularized collision
 } LBMGrid;
 
 // Initialize LBM grid

--- a/simulation/shaders/lbm_collide.comp
+++ b/simulation/shaders/lbm_collide.comp
@@ -23,6 +23,7 @@ layout(std430, binding = 5) buffer SolidMask {
 uniform ivec3 gridSize;
 uniform float tau;  // Relaxation time (viscosity related)
 uniform vec3 inletVelocity;
+uniform int useRegularized;  // 0 = BGK, 1 = regularized (stable at high Re)
 
 // D3Q19 lattice velocities
 const ivec3 e[19] = ivec3[19](
@@ -190,13 +191,72 @@ void main() {
     
     // Store velocity for particle advection
     velocity[cellIdx] = vec4(u, rho);
-    
-    // BGK collision
+
     float omega = 1.0 / tau;
-    
-    for (int i = 0; i < 19; i++) {
-        float fi = f[idxF(pos.x, pos.y, pos.z, i)];
-        float fi_eq = feq(i, rho, u);
-        f_new[idxF(pos.x, pos.y, pos.z, i)] = fi - omega * (fi - fi_eq);
+
+    if (useRegularized == 1) {
+        // Regularized collision: reconstruct distributions from the stress tensor
+        // only, filtering out unstable higher-order non-equilibrium moments.
+        // This gives MRT-like stability without the 19x19 matrix transform.
+
+        // Step 1: compute the non-equilibrium stress tensor
+        // Pi_neq_ab = sum_i (e_ia * e_ib * f_neq_i)
+        // where f_neq_i = f_i - f_eq_i
+        float Pxx = 0.0, Pyy = 0.0, Pzz = 0.0;
+        float Pxy = 0.0, Pxz = 0.0, Pyz = 0.0;
+
+        for (int i = 0; i < 19; i++) {
+            float fi = f[idxF(pos.x, pos.y, pos.z, i)];
+            float fi_eq = feq(i, rho, u);
+            float f_neq = fi - fi_eq;
+
+            float ex = float(e[i].x);
+            float ey = float(e[i].y);
+            float ez = float(e[i].z);
+
+            Pxx += ex * ex * f_neq;
+            Pyy += ey * ey * f_neq;
+            Pzz += ez * ez * f_neq;
+            Pxy += ex * ey * f_neq;
+            Pxz += ex * ez * f_neq;
+            Pyz += ey * ez * f_neq;
+        }
+
+        // Step 2: reconstruct regularized distribution
+        // f_i = f_eq_i + f_neq_reg_i
+        // f_neq_reg_i = w_i / (2 * cs^4) * Q_iab * Pi_neq_ab
+        // where Q_iab = e_ia * e_ib - cs^2 * delta_ab
+        // and cs^2 = 1/3, cs^4 = 1/9
+        float inv_2cs4 = 4.5;  // 1 / (2 * (1/9)) = 9/2
+
+        for (int i = 0; i < 19; i++) {
+            float fi_eq = feq(i, rho, u);
+
+            float ex = float(e[i].x);
+            float ey = float(e[i].y);
+            float ez = float(e[i].z);
+
+            float cs2 = 1.0 / 3.0;
+
+            // Q_iab * Pi_ab (symmetric tensor contraction)
+            float QP = (ex*ex - cs2) * Pxx
+                     + (ey*ey - cs2) * Pyy
+                     + (ez*ez - cs2) * Pzz
+                     + 2.0 * ex * ey * Pxy
+                     + 2.0 * ex * ez * Pxz
+                     + 2.0 * ey * ez * Pyz;
+
+            float f_neq_reg = w[i] * inv_2cs4 * QP;
+
+            // Collide on the regularized distribution
+            f_new[idxF(pos.x, pos.y, pos.z, i)] = fi_eq + (1.0 - omega) * f_neq_reg;
+        }
+    } else {
+        // Standard BGK (SRT) collision
+        for (int i = 0; i < 19; i++) {
+            float fi = f[idxF(pos.x, pos.y, pos.z, i)];
+            float fi_eq = feq(i, rho, u);
+            f_new[idxF(pos.x, pos.y, pos.z, i)] = fi - omega * (fi - fi_eq);
+        }
     }
 }

--- a/simulation/src/lbm.c
+++ b/simulation/src/lbm.c
@@ -89,11 +89,14 @@ LBMGrid* LBM_Create(int sizeX, int sizeY, int sizeZ, float viscosity) {
         printf("Warning: Force shader not loaded, drag calculation disabled\n");
     }
     
+    grid->useRegularized = 0;
+
     // Get uniform locations
     glUseProgram(grid->collideShader);
     grid->collide_gridSizeLoc = glGetUniformLocation(grid->collideShader, "gridSize");
     grid->collide_tauLoc = glGetUniformLocation(grid->collideShader, "tau");
     grid->collide_inletVelLoc = glGetUniformLocation(grid->collideShader, "inletVelocity");
+    grid->collide_useRegularizedLoc = glGetUniformLocation(grid->collideShader, "useRegularized");
     
     glUseProgram(grid->streamShader);
     grid->stream_gridSizeLoc = glGetUniformLocation(grid->streamShader, "gridSize");
@@ -203,6 +206,7 @@ void LBM_Step(LBMGrid* grid, float inletVelX, float inletVelY, float inletVelZ) 
     glUniform3i(grid->collide_gridSizeLoc, grid->sizeX, grid->sizeY, grid->sizeZ);
     glUniform1f(grid->collide_tauLoc, grid->tau);
     glUniform3f(grid->collide_inletVelLoc, inletVelX, inletVelY, inletVelZ);
+    glUniform1i(grid->collide_useRegularizedLoc, grid->useRegularized);
     
     glDispatchCompute((grid->sizeX + 7) / 8, (grid->sizeY + 7) / 8, (grid->sizeZ + 7) / 8);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);

--- a/simulation/src/main.c
+++ b/simulation/src/main.c
@@ -616,6 +616,13 @@ int main(int argc, char* argv[]) {
                             carBounds.minX, carBounds.minY, carBounds.minZ,
                             carBounds.maxX, carBounds.maxY, carBounds.maxZ);
         }
+        // Auto-enable regularized collision when tau is low (high Re).
+        // Standard BGK becomes unstable below ~0.55.
+        if (lbmGrid->tau < 0.6f) {
+            lbmGrid->useRegularized = 1;
+            printf("Regularized collision enabled (tau=%.3f near stability limit)\n", lbmGrid->tau);
+        }
+
         LBM_InitializeFlow(lbmGrid, windSpeed * 0.05f, 0.0f, 0.0f);
         printf("LBM initialized successfully\n");
     } else {


### PR DESCRIPTION
## Summary
- Adds a regularized collision operator as an alternative to BGK (SRT)
- Reconstructs distributions from the stress tensor only, filtering out unstable higher-order moments
- Similar stability to full MRT but way simpler (no 19x19 matrix)
- Auto-enables when tau < 0.6 (high Re), keeps BGK path for normal use
- Controlled by `useRegularized` uniform in the collision shader

BGK blows up when tau gets close to 0.5, which is exactly what happens when you crank up the Reynolds number. This lets the Re slider go much higher without crashing.

Closes #35

## Test plan
- [ ] Run with `--reynolds=50000` and verify no blowup
- [ ] Compare Cd at default Re between BGK and regularized (should be close)
- [ ] Verify auto-enable kicks in when tau < 0.6