### PR TITLE
Remove decorative comment separators and add ML CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,70 @@ jobs:
           cd simulation
           xvfb-run bash test/test_integration.sh
 
+  test-ml:
+    name: ML pipeline tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install numpy torch --index-url https://download.pytorch.org/whl/cpu pyyaml requests
+
+      - name: FFD self-tests
+        run: python ml/shapeopt/ffd.py
+
+      - name: Smoke test shapeopt imports
+        working-directory: ml/shapeopt
+        run: |
+          python -c "
+          from train_shapeopt import ShapeOptSurrogate, SwiGLU, load_sobin
+          from optimize import ShapeOptSurrogate as OptModel
+          from gen_shapes import export_sobin, sample_id
+          from ffd import FFDLattice, load_obj, save_obj, compute_bbox
+          print('shapeopt imports OK')
+          "
+
+      - name: Smoke test superres imports
+        working-directory: ml/superres
+        run: |
+          python -c "
+          from gen_pairs import write_srbin, read_srbin, extract_patches, downsample_2x
+          from train_superres import *
+          print('superres imports OK')
+          "
+
+      - name: Validate .srbin round-trip
+        working-directory: ml/superres
+        run: |
+          python -c "
+          import numpy as np
+          import tempfile
+          from pathlib import Path
+          from gen_pairs import write_srbin, read_srbin
+
+          rng = np.random.default_rng(42)
+          n_patches = 16
+          coarse = [rng.standard_normal((3,3,3,4)).astype(np.float32) for _ in range(n_patches)]
+          fine = [rng.standard_normal((2,2,2,4)).astype(np.float32) for _ in range(n_patches)]
+
+          with tempfile.NamedTemporaryFile(suffix='.srbin', delete=False) as f:
+              path = Path(f.name)
+          write_srbin(path, coarse, fine)
+          coarse_out, fine_out = read_srbin(path)
+
+          assert coarse_out.shape == (n_patches, 3, 3, 3, 4), f'coarse shape: {coarse_out.shape}'
+          assert fine_out.shape == (n_patches, 2, 2, 2, 4), f'fine shape: {fine_out.shape}'
+          for i in range(n_patches):
+              assert np.allclose(coarse_out[i], coarse[i], atol=1e-7), f'coarse mismatch at {i}'
+              assert np.allclose(fine_out[i], fine[i], atol=1e-7), f'fine mismatch at {i}'
+          path.unlink()
+          print(f'srbin round-trip OK ({n_patches} patches)')
+          "
+
   build-website:
     name: Build website (Next.js)
     runs-on: ubuntu-latest

--- a/ml/evaluate.py
+++ b/ml/evaluate.py
@@ -22,9 +22,7 @@ ML_DIR = Path(__file__).parent
 MODEL_IDS = {0: "car", 1: "ahmed25", 2: "ahmed35"}
 
 
-# ---------------------------------------------------------------------------
 # Weight loading (matches weights_io.cpp LTWS format)
-# ---------------------------------------------------------------------------
 
 def load_weights(path: str) -> list[np.ndarray]:
     """Load parameter tensors from a LTWS binary file."""
@@ -55,9 +53,7 @@ def load_normalizer(path: str) -> tuple[np.ndarray, np.ndarray]:
     return mean, std
 
 
-# ---------------------------------------------------------------------------
 # Dataset loading (matches training_data.bin format)
-# ---------------------------------------------------------------------------
 
 def load_dataset(path: str) -> np.ndarray:
     """
@@ -76,9 +72,7 @@ def load_dataset(path: str) -> np.ndarray:
         return data.reshape(num_records, num_features)
 
 
-# ---------------------------------------------------------------------------
 # Model forward pass (numpy, matches train.cpp SurrogateModel)
-# ---------------------------------------------------------------------------
 
 def swish(x: np.ndarray) -> np.ndarray:
     sig = 1.0 / (1.0 + np.exp(-np.clip(x, -88, 88)))
@@ -120,9 +114,7 @@ def forward(x: np.ndarray, params: list[np.ndarray]) -> np.ndarray:
     return out
 
 
-# ---------------------------------------------------------------------------
 # Metrics
-# ---------------------------------------------------------------------------
 
 def compute_metrics(true: np.ndarray, pred: np.ndarray) -> dict:
     err = pred - true
@@ -151,9 +143,7 @@ def print_metrics(name: str, m: dict, indent: int = 0):
     print(f"{pad}  Mean pred = {m['mean_pred']:.6f}")
 
 
-# ---------------------------------------------------------------------------
 # Plots
-# ---------------------------------------------------------------------------
 
 def generate_plots(
     dataset: np.ndarray,
@@ -174,7 +164,7 @@ def generate_plots(
     colors = {0: "#e06c75", 1: "#61afef", 2: "#98c379"}
     labels = MODEL_IDS
 
-    # -- Cd: predicted vs true scatter --
+    # Cd: predicted vs true scatter
     fig, ax = plt.subplots(figsize=(6, 6))
     for mid in sorted(MODEL_IDS.keys()):
         mask = model_ids == mid
@@ -194,7 +184,7 @@ def generate_plots(
     fig.savefig(output_dir / "cd_scatter.png", dpi=150)
     plt.close(fig)
 
-    # -- Cl: predicted vs true scatter --
+    # Cl: predicted vs true scatter
     fig, ax = plt.subplots(figsize=(6, 6))
     for mid in sorted(MODEL_IDS.keys()):
         mask = model_ids == mid
@@ -214,7 +204,7 @@ def generate_plots(
     fig.savefig(output_dir / "cl_scatter.png", dpi=150)
     plt.close(fig)
 
-    # -- Error distribution histograms --
+    # Error distribution histograms
     fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
     axes[0].hist(cd_pred - cd_true, bins=30, color="#e06c75", edgecolor="white", alpha=0.8)
@@ -233,7 +223,7 @@ def generate_plots(
     fig.savefig(output_dir / "error_distribution.png", dpi=150)
     plt.close(fig)
 
-    # -- Per-model error boxplots --
+    # Per-model error boxplots
     fig, axes = plt.subplots(1, 2, figsize=(10, 4))
     cd_errors_by_model = []
     cl_errors_by_model = []
@@ -256,7 +246,7 @@ def generate_plots(
     fig.savefig(output_dir / "error_by_model.png", dpi=150)
     plt.close(fig)
 
-    # -- Cd error vs wind speed --
+    # Cd error vs wind speed
     fig, ax = plt.subplots(figsize=(8, 4))
     for mid in sorted(MODEL_IDS.keys()):
         mask = model_ids == mid
@@ -275,9 +265,7 @@ def generate_plots(
     print(f"\nPlots saved to {output_dir}/")
 
 
-# ---------------------------------------------------------------------------
 # Main
-# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(

--- a/ml/shapeopt/ffd.py
+++ b/ml/shapeopt/ffd.py
@@ -22,9 +22,7 @@ import numpy as np
 from pathlib import Path
 
 
-# ---------------------------------------------------------------------------
 # Bernstein basis
-# ---------------------------------------------------------------------------
 
 def _binomial_coeffs(n):
     """Row n of Pascal's triangle, computed iteratively to avoid scipy."""
@@ -48,9 +46,7 @@ def _bernstein_basis(n, t):
     return basis
 
 
-# ---------------------------------------------------------------------------
 # FFDLattice
-# ---------------------------------------------------------------------------
 
 class FFDLattice:
     """Trivariate Bernstein FFD lattice for deforming 3D meshes."""
@@ -84,9 +80,7 @@ class FFDLattice:
         # Physical positions of undeformed control points
         self.control_points = self.bbox_min + self._param_grid * self.extent
 
-    # ------------------------------------------------------------------
     # Core deformation
-    # ------------------------------------------------------------------
 
     def deform(self, vertices, displacements):
         """
@@ -131,9 +125,7 @@ class FFDLattice:
 
         return deformed
 
-    # ------------------------------------------------------------------
     # Symmetry
-    # ------------------------------------------------------------------
 
     def enforce_symmetry(self, displacements, axis=1):
         """
@@ -191,9 +183,7 @@ class FFDLattice:
 
         return d.ravel()
 
-    # ------------------------------------------------------------------
     # Parameter counts
-    # ------------------------------------------------------------------
 
     def get_num_params(self):
         """Total displacement DOFs: nx * ny * nz * 3."""
@@ -217,9 +207,7 @@ class FFDLattice:
 
         return free
 
-    # ------------------------------------------------------------------
     # Clamping
-    # ------------------------------------------------------------------
 
     def clamp_displacements(self, displacements, max_fraction=0.15):
         """
@@ -241,9 +229,7 @@ class FFDLattice:
             np.clip(d[..., comp], -limits[comp], limits[comp], out=d[..., comp])
         return d.ravel()
 
-    # ------------------------------------------------------------------
     # Random sampling (Latin Hypercube)
-    # ------------------------------------------------------------------
 
     def sample_random(self, n_samples, max_fraction=0.15, symmetric=True):
         """
@@ -338,9 +324,7 @@ class FFDLattice:
         return d.ravel()
 
 
-# ---------------------------------------------------------------------------
 # OBJ I/O
-# ---------------------------------------------------------------------------
 
 def load_obj(path):
     """
@@ -424,9 +408,7 @@ def deform_obj(input_path, output_path, displacements, n_control=(4, 3, 3)):
     save_obj(output_path, deformed, faces)
 
 
-# ---------------------------------------------------------------------------
 # Self-tests
-# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     import sys
@@ -444,7 +426,7 @@ if __name__ == "__main__":
             print(f"  FAIL  {name}")
             failed += 1
 
-    # --- Unit cube vertices ---
+    # Unit cube vertices
     cube_verts = np.array([
         [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
         [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
@@ -458,7 +440,7 @@ if __name__ == "__main__":
         [1, 2, 6], [1, 6, 5],
     ], dtype=np.int64)
 
-    # --- Test 1: Identity deformation ---
+    # Test 1: Identity deformation
     print("Test 1: Zero displacements preserve vertex positions")
     bbox_min, bbox_max = compute_bbox(cube_verts, padding=0.0)
     lattice = FFDLattice(bbox_min, bbox_max, n_control=(4, 3, 3))
@@ -467,7 +449,7 @@ if __name__ == "__main__":
     max_err = np.max(np.abs(deformed - cube_verts))
     check("max error < 1e-12", max_err < 1e-12)
 
-    # --- Test 2: Uniform translation ---
+    # Test 2: Uniform translation
     print("Test 2: Uniform displacement translates all vertices equally")
     lattice2 = FFDLattice(bbox_min, bbox_max, n_control=(2, 2, 2))
     shift = np.zeros((2, 2, 2, 3))
@@ -478,14 +460,14 @@ if __name__ == "__main__":
     max_err2 = np.max(np.abs(deformed2 - expected))
     check("uniform X shift matches", max_err2 < 1e-12)
 
-    # --- Test 3: Parameter counts ---
+    # Test 3: Parameter counts
     print("Test 3: Parameter counts")
     lattice3 = FFDLattice([0, 0, 0], [1, 1, 1], n_control=(4, 3, 3))
     check("total params = 4*3*3*3 = 108", lattice3.get_num_params() == 108)
     # ny=3: half=1 paired, 1 midplane. Free = 4*1*3*3 + 4*1*3*2 = 36 + 24 = 60
     check("free params after Y-symmetry = 60", lattice3.get_num_free_params() == 60)
 
-    # --- Test 4: Symmetry enforcement ---
+    # Test 4: Symmetry enforcement
     print("Test 4: Symmetry enforcement")
     rng = np.random.default_rng(42)
     raw = rng.standard_normal(lattice3.get_num_params()) * 0.01
@@ -504,7 +486,7 @@ if __name__ == "__main__":
     mid_y_zero = np.allclose(sym_4d[:, 1, :, 1], 0.0)
     check("midplane y displacement = 0", mid_y_zero)
 
-    # --- Test 5: Clamping ---
+    # Test 5: Clamping
     print("Test 5: Displacement clamping")
     big_disp = np.ones(lattice3.get_num_params()) * 10.0
     clamped = lattice3.clamp_displacements(big_disp, max_fraction=0.15)
@@ -516,7 +498,7 @@ if __name__ == "__main__":
             within = False
     check("all components within limits", within)
 
-    # --- Test 6: OBJ round-trip ---
+    # Test 6: OBJ round-trip
     print("Test 6: OBJ I/O round-trip")
     with tempfile.NamedTemporaryFile(suffix=".obj", delete=False, mode="w") as tmp:
         tmp_path = tmp.name
@@ -526,7 +508,7 @@ if __name__ == "__main__":
     check("faces survive round-trip", np.array_equal(loaded_f, cube_faces))
     Path(tmp_path).unlink()
 
-    # --- Test 7: deform_obj convenience ---
+    # Test 7: deform_obj convenience
     print("Test 7: deform_obj end-to-end")
     with tempfile.NamedTemporaryFile(suffix=".obj", delete=False, mode="w") as src:
         src_path = src.name
@@ -544,7 +526,7 @@ if __name__ == "__main__":
     Path(src_path).unlink()
     Path(dst_path).unlink()
 
-    # --- Test 8: LHS sampling shape ---
+    # Test 8: LHS sampling shape
     print("Test 8: Latin Hypercube Sampling")
     samples = lattice3.sample_random(10, max_fraction=0.15, symmetric=True)
     check("LHS output shape (10, 108)", samples.shape == (10, 108))
@@ -557,7 +539,7 @@ if __name__ == "__main__":
             break
     check("all LHS samples are symmetric", sym_ok)
 
-    # --- Test 9: Bernstein partition of unity ---
+    # Test 9: Bernstein partition of unity
     print("Test 9: Bernstein basis partition of unity")
     t_vals = np.linspace(0, 1, 50)
     for deg in [2, 3, 5]:
@@ -565,6 +547,6 @@ if __name__ == "__main__":
         sums = basis.sum(axis=1)
         check(f"degree {deg} sums to 1", np.allclose(sums, 1.0, atol=1e-14))
 
-    # --- Summary ---
+    # Summary
     print(f"\n{passed} passed, {failed} failed")
     sys.exit(1 if failed else 0)

--- a/ml/shapeopt/gen_shapes.py
+++ b/ml/shapeopt/gen_shapes.py
@@ -29,9 +29,7 @@ import yaml
 
 from ffd import FFDLattice, load_obj, save_obj, compute_bbox
 
-# ---------------------------------------------------------------------------
 # Paths
-# ---------------------------------------------------------------------------
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SHAPEOPT_DIR = Path(__file__).resolve().parent
@@ -51,18 +49,14 @@ SOBIN_MAGIC = 0x534F5054
 SOBIN_VERSION = 1
 
 
-# ---------------------------------------------------------------------------
 # Config
-# ---------------------------------------------------------------------------
 
 def load_config(config_path: str) -> dict:
     with open(config_path) as f:
         return yaml.safe_load(f)
 
 
-# ---------------------------------------------------------------------------
 # OBJ encoding
-# ---------------------------------------------------------------------------
 
 def obj_to_base64(vertices: np.ndarray, faces: np.ndarray) -> str:
     """Encode a mesh as a base64 OBJ string for the Modal endpoint."""
@@ -75,9 +69,7 @@ def obj_to_base64(vertices: np.ndarray, faces: np.ndarray) -> str:
     return base64.b64encode(buf.getvalue().encode("utf-8")).decode("ascii")
 
 
-# ---------------------------------------------------------------------------
 # Modal submission with async polling
-# ---------------------------------------------------------------------------
 
 def submit_job(endpoint: str, payload: dict, timeout: int = 30) -> str | None:
     """POST to the render endpoint. Returns a job_id on success, None on error."""
@@ -152,9 +144,7 @@ def run_simulation(endpoint: str, payload: dict) -> dict:
     return poll_result
 
 
-# ---------------------------------------------------------------------------
 # Sample tracking
-# ---------------------------------------------------------------------------
 
 def sample_id(model: str, idx: int) -> str:
     key = f"shapeopt_{model}_{idx}"
@@ -211,9 +201,7 @@ def save_results_row(sid: str, model: str, idx: int,
         ])
 
 
-# ---------------------------------------------------------------------------
 # Binary export (.sobin)
-# ---------------------------------------------------------------------------
 
 def export_sobin(results_file: Path, output_file: Path):
     """
@@ -277,9 +265,7 @@ def export_sobin(results_file: Path, output_file: Path):
     return len(records)
 
 
-# ---------------------------------------------------------------------------
 # Main pipeline
-# ---------------------------------------------------------------------------
 
 def run_sweep(config_path: str, endpoint: str, resume: bool = False):
     config = load_config(config_path)
@@ -462,9 +448,7 @@ def show_status():
         print(f"\n  Binary: {SOBIN_FILE} ({size_kb:.1f} KB)")
 
 
-# ---------------------------------------------------------------------------
 # CLI
-# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(

--- a/ml/shapeopt/optimize.py
+++ b/ml/shapeopt/optimize.py
@@ -34,9 +34,7 @@ MODEL_OBJ_PATHS = {
 }
 
 
-# ---------------------------------------------------------------------------
 # Model definition (must match train_shapeopt.py)
-# ---------------------------------------------------------------------------
 
 class SwiGLU(torch.nn.Module):
     def __init__(self, in_dim: int, hidden_dim: int):
@@ -66,9 +64,7 @@ class ShapeOptSurrogate(torch.nn.Module):
         return self.fc3(h)
 
 
-# ---------------------------------------------------------------------------
 # Modal submission helpers (same pattern as gen_shapes.py)
-# ---------------------------------------------------------------------------
 
 def obj_to_base64(vertices: np.ndarray, faces: np.ndarray) -> str:
     buf = io.StringIO()
@@ -115,9 +111,7 @@ def submit_and_poll(endpoint: str, payload: dict,
     return {"status": "error", "error": f"Timed out after {timeout}s"}
 
 
-# ---------------------------------------------------------------------------
 # Optimization
-# ---------------------------------------------------------------------------
 
 def optimize(args):
     # Load base mesh
@@ -292,9 +286,7 @@ def optimize(args):
             print(f"{step:6d}  {cd:10.6f}  {cl:10.6f}  {md:12.6f}")
 
 
-# ---------------------------------------------------------------------------
 # CLI
-# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(

--- a/ml/shapeopt/train_shapeopt.py
+++ b/ml/shapeopt/train_shapeopt.py
@@ -26,9 +26,7 @@ LTWS_MAGIC = 0x4C545753
 LTWS_VERSION = 1
 
 
-# ---------------------------------------------------------------------------
 # Dataset loading (.sobin)
-# ---------------------------------------------------------------------------
 
 def load_sobin(path: str) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -58,9 +56,7 @@ def load_sobin(path: str) -> tuple[np.ndarray, np.ndarray]:
     return displacements, outputs
 
 
-# ---------------------------------------------------------------------------
 # SwiGLU building block
-# ---------------------------------------------------------------------------
 
 class SwiGLU(nn.Module):
     """
@@ -83,9 +79,7 @@ class SwiGLU(nn.Module):
         return self.w_down(F.silu(self.w_gate(x)) * self.w_up(x))
 
 
-# ---------------------------------------------------------------------------
 # Surrogate model
-# ---------------------------------------------------------------------------
 
 class ShapeOptSurrogate(nn.Module):
     """
@@ -115,9 +109,7 @@ class ShapeOptSurrogate(nn.Module):
         return self.fc3(h)
 
 
-# ---------------------------------------------------------------------------
 # LTWS export (matches ml/superres/export_weights.py)
-# ---------------------------------------------------------------------------
 
 def export_ltws(state_dict: dict, output_path: str):
     """
@@ -162,9 +154,7 @@ def save_normalizer(means: np.ndarray, stds: np.ndarray, output_path: str):
     print(f"Saved normalizer ({len(means)} dims) to {output_path}")
 
 
-# ---------------------------------------------------------------------------
 # Training loop
-# ---------------------------------------------------------------------------
 
 def train(args):
     print(f"Loading dataset: {args.data}")
@@ -337,9 +327,7 @@ def train(args):
     save_normalizer(feat_mean, feat_std, str(norm_path))
 
 
-# ---------------------------------------------------------------------------
 # CLI
-# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(

--- a/ml/superres/gen_pairs.py
+++ b/ml/superres/gen_pairs.py
@@ -32,9 +32,7 @@ from pathlib import Path
 import numpy as np
 import yaml
 
-# ---------------------------------------------------------------------------
 # Paths
-# ---------------------------------------------------------------------------
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SIM_BINARY = PROJECT_ROOT / "build" / "3d_fluid_simulation_car"
@@ -57,9 +55,7 @@ MODEL_OBJ_PATHS = {
 }
 
 
-# ---------------------------------------------------------------------------
 # Config types
-# ---------------------------------------------------------------------------
 
 @dataclass
 class PairConfig:
@@ -102,9 +98,7 @@ class PatchAccumulator:
         return len(self.coarse_inputs)
 
 
-# ---------------------------------------------------------------------------
 # YAML config loading
-# ---------------------------------------------------------------------------
 
 def load_config(config_path: str) -> dict:
     with open(config_path) as f:
@@ -130,9 +124,7 @@ def generate_pair_configs(config: dict) -> list[PairConfig]:
     return pairs
 
 
-# ---------------------------------------------------------------------------
 # VTI parsing
-# ---------------------------------------------------------------------------
 
 def parse_grid_dims(extent_str: str) -> tuple[int, int, int]:
     """Parse WholeExtent='0 NX 0 NY 0 NZ' into (NX, NY, NZ) cell counts.
@@ -259,9 +251,7 @@ def parse_vti(
     return velocity, rho, solid, (nx, ny, nz)
 
 
-# ---------------------------------------------------------------------------
 # Downsampling and patch extraction
-# ---------------------------------------------------------------------------
 
 def compute_density(
     velocity: np.ndarray, rho: np.ndarray | None = None
@@ -399,9 +389,7 @@ def extract_patches(
     return coarse_patches, fine_patches
 
 
-# ---------------------------------------------------------------------------
 # Simulation runner
-# ---------------------------------------------------------------------------
 
 def run_simulation(
     model: str,
@@ -531,9 +519,7 @@ def run_simulation_modal(
     return True, f"Downloaded {len(fields)} VTK files from Modal"
 
 
-# ---------------------------------------------------------------------------
 # .srbin I/O
-# ---------------------------------------------------------------------------
 
 def write_srbin(
     filepath: Path,
@@ -608,9 +594,7 @@ def read_srbin(filepath: Path) -> tuple[np.ndarray, np.ndarray]:
     )
 
 
-# ---------------------------------------------------------------------------
 # Manifest tracking
-# ---------------------------------------------------------------------------
 
 def load_manifest() -> dict:
     if MANIFEST_FILE.exists():
@@ -629,9 +613,7 @@ def load_completed_ids(manifest: dict) -> set[str]:
     return set(manifest.get("completed", {}).keys())
 
 
-# ---------------------------------------------------------------------------
 # Pipeline: process one pair config
-# ---------------------------------------------------------------------------
 
 def process_pair(
     pc: PairConfig,
@@ -712,9 +694,7 @@ def process_pair(
     )
 
 
-# ---------------------------------------------------------------------------
 # Main pipeline
-# ---------------------------------------------------------------------------
 
 def run_pipeline(config_path: str, resume: bool = False, use_modal: bool = False):
     config = load_config(config_path)
@@ -830,9 +810,7 @@ def save_stats(manifest: dict, accumulator: PatchAccumulator):
         print(f"  {model}: {ms['configs']} configs, {ms['patches']} patches")
 
 
-# ---------------------------------------------------------------------------
 # Status display
-# ---------------------------------------------------------------------------
 
 def show_status():
     """Show current state of data generation."""
@@ -899,9 +877,7 @@ def verify_srbin():
     print(f"  Coarse rho range: [{coarse[..., 3].min():.4f}, {coarse[..., 3].max():.4f}]")
 
 
-# ---------------------------------------------------------------------------
 # CLI
-# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(

--- a/ml/train.cpp
+++ b/ml/train.cpp
@@ -23,9 +23,7 @@
 #include <string>
 #include <vector>
 
-// ---------------------------------------------------------------------------
 // Dataset loading
-// ---------------------------------------------------------------------------
 
 struct Sample {
     float wind_speed;
@@ -78,9 +76,7 @@ struct Dataset {
     }
 };
 
-// ---------------------------------------------------------------------------
 // Normalization: z-score per feature
-// ---------------------------------------------------------------------------
 
 struct Normalizer {
     float mean[3];
@@ -118,9 +114,7 @@ struct Normalizer {
     }
 };
 
-// ---------------------------------------------------------------------------
 // Pack samples into [features x batch] tensors
-// ---------------------------------------------------------------------------
 
 static std::shared_ptr<ADTensor> pack_inputs(
     const std::vector<Sample>& samples,
@@ -150,12 +144,10 @@ static std::shared_ptr<ADTensor> pack_targets(
     return make_ad(t);
 }
 
-// ---------------------------------------------------------------------------
 // Model: MLP with SwiGLU activations
 //   Linear(3, 256) -> SwiGLU(256, 512)
 //   -> Linear(256, 128) -> SwiGLU(128, 256)
 //   -> Linear(128, 2)
-// ---------------------------------------------------------------------------
 
 struct SurrogateModel {
     ADLinear fc1{3, 256};
@@ -171,9 +163,7 @@ struct SurrogateModel {
     }
 };
 
-// ---------------------------------------------------------------------------
 // Evaluate on a set of indices, return mean L1 error for Cd and Cl
-// ---------------------------------------------------------------------------
 
 static void evaluate(SurrogateModel& model,
                      const std::vector<Sample>& samples,
@@ -194,9 +184,7 @@ static void evaluate(SurrogateModel& model,
     *cl_mae = cl_err / B;
 }
 
-// ---------------------------------------------------------------------------
 // main
-// ---------------------------------------------------------------------------
 
 int main(int argc, char* argv[]) {
     std::string data_path = "dataset/training_data.bin";

--- a/simulation/src/lbm.c
+++ b/simulation/src/lbm.c
@@ -731,7 +731,7 @@ void LBM_Step(LBMGrid *grid,
     int dispX = (grid->sizeX + 7) / 8;
     int dispY = (grid->sizeY + 7) / 8;
 
-    // --- Collision: per-slab dispatch ---
+    // Collision: per-slab dispatch
     glUseProgram(grid->collideShader);
     glUniform1f(grid->collide_tauLoc, grid->tau);
     glUniform3f(grid->collide_inletVelLoc, inletVelX, inletVelY, inletVelZ);
@@ -767,7 +767,7 @@ void LBM_Step(LBMGrid *grid,
     }
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // --- Streaming: per-slab dispatch with halo ---
+    // Streaming: per-slab dispatch with halo
     glUseProgram(grid->streamShader);
     glUniform3i(
         grid->stream_gridSizeLoc, grid->sizeX, grid->sizeY, grid->sizeZ);

--- a/simulation/src/ml_predict.c
+++ b/simulation/src/ml_predict.c
@@ -59,9 +59,7 @@ struct MLPredictor {
     float fc3_b[OUT_DIM];        // [2 x 1]
 };
 
-// --------------------------------------------------------------------
 // Helpers
-// --------------------------------------------------------------------
 
 // Read one parameter blob from the file and copy into dst.
 // Validates ndim, shape, and total element count.
@@ -142,9 +140,7 @@ static void swiglu_forward(const float *Wg, const float *Wu,
     matvec(Wd, tmp_gate, out, embed_dim, hidden_dim);
 }
 
-// --------------------------------------------------------------------
 // Public API
-// --------------------------------------------------------------------
 
 MLPredictor *ML_Load(const char *weights_path,
                      const char *norm_path) {
@@ -153,7 +149,7 @@ MLPredictor *ML_Load(const char *weights_path,
     if (!m)
         return NULL;
 
-    // -- Load normalizer --
+    // Load normalizer
     FILE *nf = fopen(norm_path, "rb");
     if (!nf) {
         fprintf(stderr, "ml_predict: cannot open %s\n", norm_path);
@@ -169,7 +165,7 @@ MLPredictor *ML_Load(const char *weights_path,
     }
     fclose(nf);
 
-    // -- Load weights --
+    // Load weights
     FILE *wf = fopen(weights_path, "rb");
     if (!wf) {
         fprintf(stderr, "ml_predict: cannot open %s\n",

--- a/website/src/app/comparison/page.tsx
+++ b/website/src/app/comparison/page.tsx
@@ -10,9 +10,7 @@ function clamp(v: number, lo: number, hi: number) {
   return Math.max(lo, Math.min(hi, v));
 }
 
-// ---------------------------------------------------------------------------
 // Stat card
-// ---------------------------------------------------------------------------
 
 function StatCard({
   label,
@@ -74,9 +72,7 @@ function StatCard({
   );
 }
 
-// ---------------------------------------------------------------------------
 // Scatter chart: ML vs LBM for all historical results
-// ---------------------------------------------------------------------------
 
 function ComparisonChart({
   pairs,
@@ -204,9 +200,7 @@ function ComparisonChart({
   );
 }
 
-// ---------------------------------------------------------------------------
 // Sweep table: ML predictions across wind speeds for selected model
-// ---------------------------------------------------------------------------
 
 function SweepTable({
   model,
@@ -274,9 +268,7 @@ function SweepTable({
   );
 }
 
-// ---------------------------------------------------------------------------
 // Main page
-// ---------------------------------------------------------------------------
 
 export default function ComparisonPage() {
   const { status: mlStatus, predict: mlPredict } = useSurrogate();

--- a/website/src/app/optimize/page.tsx
+++ b/website/src/app/optimize/page.tsx
@@ -22,9 +22,7 @@ function clamp(v: number, lo: number, hi: number) {
   return Math.max(lo, Math.min(hi, v));
 }
 
-// -----------------------------------------------------------------------
 // SPSA optimizer -- 2 forward passes per step regardless of dimension
-// -----------------------------------------------------------------------
 
 interface SPSAConfig {
   a: number;     // step size scale
@@ -92,9 +90,7 @@ function spsaStep(
   };
 }
 
-// -----------------------------------------------------------------------
 // Mini Cd-vs-iteration chart (inline SVG)
-// -----------------------------------------------------------------------
 
 function ConvergenceChart({ cdHistory }: { cdHistory: number[] }) {
   if (cdHistory.length < 2) return null;
@@ -178,9 +174,7 @@ function ConvergenceChart({ cdHistory }: { cdHistory: number[] }) {
   );
 }
 
-// -----------------------------------------------------------------------
 // Main page
-// -----------------------------------------------------------------------
 
 type RunStatus = 'idle' | 'loading-model' | 'running' | 'done' | 'error';
 

--- a/website/src/lib/shapeopt_surrogate.ts
+++ b/website/src/lib/shapeopt_surrogate.ts
@@ -12,9 +12,7 @@
 
 'use client';
 
-// -----------------------------------------------------------------------
 // Binary format constants (must match ml/framework/src/weights_io.cpp)
-// -----------------------------------------------------------------------
 
 const MAGIC = 0x4c545753;
 const VERSION = 1;
@@ -30,9 +28,7 @@ const OUT = 2;
 
 const NUM_FFD = 108;
 
-// -----------------------------------------------------------------------
 // Math helpers
-// -----------------------------------------------------------------------
 
 function matvec(W: Float32Array, x: Float32Array, rows: number, cols: number): Float32Array {
   const y = new Float32Array(rows);
@@ -74,9 +70,7 @@ function swigluForward(
   return matvec(Wd, gate, embedDim, hiddenDim);
 }
 
-// -----------------------------------------------------------------------
 // Weight loading
-// -----------------------------------------------------------------------
 
 interface Weights {
   fc1W: Float32Array;
@@ -155,9 +149,7 @@ function parseNorm(buf: ArrayBuffer): Normalizer {
   };
 }
 
-// -----------------------------------------------------------------------
 // Forward pass
-// -----------------------------------------------------------------------
 
 export interface ShapeOptModel {
   weights: Weights;
@@ -201,9 +193,7 @@ function forward(w: Weights, x: Float32Array): { cd: number; cl: number } {
   return { cd: out[0], cl: out[1] };
 }
 
-// -----------------------------------------------------------------------
 // Public API
-// -----------------------------------------------------------------------
 
 export async function loadShapeOptSurrogate(): Promise<ShapeOptModel> {
   const [wBuf, nBuf] = await Promise.all([

--- a/website/src/lib/surrogate.ts
+++ b/website/src/lib/surrogate.ts
@@ -11,9 +11,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 
-// -----------------------------------------------------------------------
 // Binary format constants (must match ml/framework/src/weights_io.cpp)
-// -----------------------------------------------------------------------
 
 const MAGIC = 0x4c545753;
 const VERSION = 1;
@@ -34,9 +32,7 @@ const MODEL_IDS: Record<string, number> = {
   ahmed35: 2,
 };
 
-// -----------------------------------------------------------------------
 // Math helpers
-// -----------------------------------------------------------------------
 
 function matvec(W: Float32Array, x: Float32Array, rows: number, cols: number): Float32Array {
   const y = new Float32Array(rows);
@@ -78,9 +74,7 @@ function swigluForward(
   return matvec(Wd, gate, embedDim, hiddenDim);
 }
 
-// -----------------------------------------------------------------------
 // Weight loading
-// -----------------------------------------------------------------------
 
 interface Weights {
   fc1W: Float32Array;
@@ -158,9 +152,7 @@ function parseNorm(buf: ArrayBuffer): Normalizer {
   };
 }
 
-// -----------------------------------------------------------------------
 // Forward pass
-// -----------------------------------------------------------------------
 
 export interface Prediction {
   cd: number;
@@ -195,9 +187,7 @@ function forward(w: Weights, norm: Normalizer, windSpeed: number, reynolds: numb
   return { cd: out[0], cl: out[1] };
 }
 
-// -----------------------------------------------------------------------
 // React hook
-// -----------------------------------------------------------------------
 
 export type ModelStatus = 'idle' | 'loading' | 'ready' | 'error';
 


### PR DESCRIPTION
## Summary
- Strip all decorative separator comments (lines of `// ----` / `# ----` with no information content) across 13 source files, keeping only meaningful section-header text
- Add a `test-ml` CI job that runs FFD self-tests (17 assertions), smoke-tests shapeopt/superres module imports, and validates `.srbin` binary round-trip serialization

Closes #160

## Test plan
- [ ] FFD self-tests pass locally (`python ml/shapeopt/ffd.py` → 17 passed)
- [ ] CI `test-ml` job runs successfully on the PR
- [ ] No functional code changes — only comment lines removed and CI added

🤖 Generated with [Claude Code](https://claude.com/claude-code)