### PR TITLE
Fix unchecked fwrite, propagate LBM init failure, fix SR test

### DIFF
--- a/simulation/lib/lbm.h
+++ b/simulation/lib/lbm.h
@@ -70,8 +70,8 @@ void LBM_SetSolidAABB(LBMGrid *grid,
                       float maxY,
                       float maxZ);
 
-// Initialize with uniform velocity
-void LBM_InitializeFlow(LBMGrid *grid, float ux, float uy, float uz);
+// Initialize with uniform velocity. Returns 1 on success, 0 on failure.
+int LBM_InitializeFlow(LBMGrid *grid, float ux, float uy, float uz);
 
 // Run one LBM step (collision + streaming)
 void LBM_Step(LBMGrid *grid, float inletVelX, float inletVelY, float inletVelZ);

--- a/simulation/src/lbm.c
+++ b/simulation/src/lbm.c
@@ -667,21 +667,22 @@ float LBM_ComputeProjectedArea(LBMGrid *grid, int axis) {
     return (float)count;
 }
 
-void LBM_InitializeFlow(LBMGrid *grid, float ux, float uy, float uz) {
+int LBM_InitializeFlow(LBMGrid *grid, float ux, float uy, float uz) {
     float rho = 1.0f;
 
     float *fData = (float *)malloc(19 * grid->totalCells * sizeof(float));
     float *velData = (float *)malloc(4 * grid->totalCells * sizeof(float));
 
     if (!fData || !velData) {
-        printf("ERROR: Failed to allocate CPU buffers for LBM init "
-               "(need %.1f MB)\n",
-               (19 * grid->totalCells * sizeof(float) +
-                4 * grid->totalCells * sizeof(float)) /
-                   (1024.0 * 1024.0));
+        fprintf(stderr,
+                "ERROR: Failed to allocate CPU buffers for LBM init "
+                "(need %.1f MB)\n",
+                (19 * grid->totalCells * sizeof(float) +
+                 4 * grid->totalCells * sizeof(float)) /
+                    (1024.0 * 1024.0));
         free(fData);
         free(velData);
-        return;
+        return 0;
     }
 
     for (int idx = 0; idx < grid->totalCells; idx++) {
@@ -716,6 +717,7 @@ void LBM_InitializeFlow(LBMGrid *grid, float ux, float uy, float uz) {
     free(velData);
 
     printf("LBM flow initialized: u=(%.3f, %.3f, %.3f)\n", ux, uy, uz);
+    return 1;
 }
 
 void LBM_Step(LBMGrid *grid,

--- a/simulation/src/main.c
+++ b/simulation/src/main.c
@@ -515,7 +515,11 @@ int main(int argc, char *argv[]) {
         lbmGrid->useMRT = 1;
         printf("MRT collision enabled\n");
 
-        LBM_InitializeFlow(lbmGrid, latticeVelocity, 0.0f, 0.0f);
+        if (!LBM_InitializeFlow(lbmGrid, latticeVelocity, 0.0f, 0.0f)) {
+            fprintf(stderr, "FATAL: LBM flow initialization failed\n");
+            LBM_Free(lbmGrid);
+            return 1;
+        }
 
         // Print effective Reynolds number
         {

--- a/simulation/src/vti_export.c
+++ b/simulation/src/vti_export.c
@@ -81,22 +81,32 @@ void writeVTI(LBMGrid *grid, const char *path, int step) {
 
     // Velocity array (strip w component from vec4)
     uint64_t velDataSize = (uint64_t)total * 3 * sizeof(float);
-    fwrite(&velDataSize, sizeof(uint64_t), 1, f);
-    for (int i = 0; i < total; i++) {
-        fwrite(&vel[i * 4], sizeof(float), 3, f);
+    int writeOk = 1;
+    writeOk = writeOk && fwrite(&velDataSize, sizeof(uint64_t), 1, f) == 1;
+    for (int i = 0; i < total && writeOk; i++) {
+        writeOk = fwrite(&vel[i * 4], sizeof(float), 3, f) == 3;
     }
 
     // Density (rho) array -- 4th component of the velocity vec4
     uint64_t rhoDataSize = (uint64_t)total * sizeof(float);
-    fwrite(&rhoDataSize, sizeof(uint64_t), 1, f);
-    for (int i = 0; i < total; i++) {
-        fwrite(&vel[i * 4 + 3], sizeof(float), 1, f);
+    writeOk = writeOk && fwrite(&rhoDataSize, sizeof(uint64_t), 1, f) == 1;
+    for (int i = 0; i < total && writeOk; i++) {
+        writeOk = fwrite(&vel[i * 4 + 3], sizeof(float), 1, f) == 1;
     }
 
     // Solid array
     uint64_t solidDataSize = (uint64_t)total * sizeof(int);
-    fwrite(&solidDataSize, sizeof(uint64_t), 1, f);
-    fwrite(solid, sizeof(int), total, f);
+    writeOk = writeOk && fwrite(&solidDataSize, sizeof(uint64_t), 1, f) == 1;
+    writeOk = writeOk &&
+              fwrite(solid, sizeof(int), total, f) == (size_t)total;
+
+    if (!writeOk) {
+        fprintf(stderr, "VTK: write error for %s\n", filename);
+        fclose(f);
+        free(vel);
+        free(solid);
+        return;
+    }
 
     fprintf(f, "\n  </AppendedData>\n</VTKFile>\n");
     fclose(f);

--- a/simulation/test/test_integration.sh
+++ b/simulation/test/test_integration.sh
@@ -69,7 +69,8 @@ fi
 # Test 5: --superres graceful fallback without weights
 echo "test: --superres graceful fallback without weights"
 SR_OUTPUT=$($BINARY --wind=1.0 --duration=2 --grid=32x16x16 \
-    --model=$MODEL --output=$OUTDIR --superres 2>&1)
+    --model=$MODEL --output=$OUTDIR --superres \
+    --sr-weights=/nonexistent/weights.bin 2>&1)
 if echo "$SR_OUTPUT" | grep -q "falling back to native resolution"; then
     pass "superres fallback works"
 else


### PR DESCRIPTION
## Summary
- **vti_export.c**: Check all `fwrite` return values — abort and report on write failure instead of silently producing corrupt VTK files
- **lbm.c / lbm.h**: `LBM_InitializeFlow` now returns `int` (1=success, 0=failure) so callers can detect allocation errors
- **main.c**: Exit early if LBM initialization fails
- **test_integration.sh**: Pass `--sr-weights=/nonexistent` to actually test the fallback path (the real weight files exist in `assets/`)

## Test plan
- [ ] CI build-simulation passes (integration test superres fallback now exercises the correct path)
- [ ] VTI export aborts cleanly on write error instead of producing corrupt files